### PR TITLE
Change the contributes configuration title

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "main": "./extension",
     "contributes": {
         "configuration": {
-            "title": "Px to rem configuration",
+            "title": "Px to Rem",
             "properties": {
                 "px-to-rem.px-per-rem": {
                     "type": "integer",


### PR DESCRIPTION
Hi sainoba! 

First of all, thanks for sharing awesome extension! 

I changed the title of contributes.configuration in package.json. 
According to the official document, the word "Extension", "Configuration", and "Settings" are redundant in the title. 
I shared the related image below. 
![image](https://github.com/sainoba/vscode-px-to-rem/assets/73158602/055520a4-ae2e-4626-acd8-5da221e2e3fd)

Thx:) 